### PR TITLE
Fix UI flickering introduced in b3b3c26

### DIFF
--- a/src/ui/utils/create_labeled_widgets.py
+++ b/src/ui/utils/create_labeled_widgets.py
@@ -28,7 +28,7 @@ def create_labeled_entry(
     if config:
         custom_entry.text_var.set(config.initial_value or "")
         config.on_change and custom_entry.text_var.trace_add("write", config.on_change)
-        config.force_focus and parent.after(0, lambda: parent.after(0, custom_entry.focus_force))
+        config.force_focus and parent.after(0, custom_entry.focus_force)
         config.cursor_end and custom_entry.icursor(tk.END)
 
         if config.validation_func:

--- a/src/ui/windows/base/custom_window.py
+++ b/src/ui/windows/base/custom_window.py
@@ -18,6 +18,7 @@ class CustomWindow(CustomWindowAttachMixin):
     ):
         attached_views = kwargs.pop("attached_views", None)
         super().__init__(attached_views=attached_views)
+        self.withdraw()  # Hide window initially
         self._config = config
         self.__cancelled = True
 
@@ -47,9 +48,10 @@ class CustomWindow(CustomWindowAttachMixin):
     def show(self):
         self.show_all_attached_views()
         self.update_idletasks()
-        self.after(0, self.focus_force)
+        self.deiconify()
+        self.focus_force()
+        
         self.mainloop()
-
         if self.__cancelled:
             raise UserCancelledError()
 


### PR DESCRIPTION
- Withdraw Window in constructor
- Show attached views before deiconifying

Also remove unnecessary nested "after" call hack